### PR TITLE
Fix PortAudio missing issue for Streamlit UI

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,8 +1,16 @@
 FROM python:3.9
 WORKDIR /app
+
+# Install system dependencies required for audio capture
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends portaudio19-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.ui.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
+
 COPY . ./
+
 CMD ["streamlit", "run", "app/ui/ui.py", \
      "--server.port", "5000", \
      "--server.address", "0.0.0.0", \

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 1. [Vosk](https://alphacephei.com/vosk/models) から日本語モデルをダウンロードします
 2. 展開したフォルダーのパスを `VOSK_MODEL_PATH` 環境変数に設定します
 3. UIを起動すると音声認識が利用できます
+4. Linux環境でローカル実行する場合は `portaudio19-dev` をインストールしてください
 
 ### APIの直接利用
 


### PR DESCRIPTION
## Summary
- install PortAudio in `Dockerfile.ui` so `sounddevice` works
- document PortAudio requirement for local Linux setups

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684023e85c3c833185ac87f3cea9bcba