### PR TITLE
Improve Vosk model setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@
 
 #### 音声入力を利用するには
 
-1. [Vosk](https://alphacephei.com/vosk/models) から日本語モデルをダウンロードします
-2. 展開したフォルダーのパスを `VOSK_MODEL_PATH` 環境変数に設定します
-3. UIを起動すると音声認識が利用できます
-4. Linux環境でローカル実行する場合は `portaudio19-dev` をインストールしてください
+1. 日本語モデルが存在しない場合、UI起動時に自動でダウンロードされ `./model` に展開されます
+2. オフライン環境では [Vosk](https://alphacephei.com/vosk/models) から日本語モデルを取得し、
+   展開先ディレクトリを `VOSK_MODEL_PATH` 環境変数に設定してください
+3. Linux環境でローカル実行する場合は `portaudio19-dev` をインストールしてください
 
 ### APIの直接利用
 


### PR DESCRIPTION
## Summary
- automatically download the Japanese Vosk model when missing
- clarify Japanese model instructions in README

## Testing
- `python -m py_compile app/ui/ui.py`


------
https://chatgpt.com/codex/tasks/task_e_684025cd456483318ef8f9a59537dad0