### PR TITLE
Improve Vosk model setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,12 @@
 
 #### 音声入力を利用するには
 
-1. [Vosk](https://alphacephei.com/vosk/models) から日本語モデルをダウンロードします
-2. 展開したフォルダーのパスを `VOSK_MODEL_PATH` 環境変数に設定します
-3. UIを起動すると音声認識が利用できます
-4. Linux環境でローカル実行する場合は `portaudio19-dev` をインストールしてください
+1. 日本語モデルが存在しない場合、UI起動時に自動でダウンロードされ `./model` に展開されます
+2. オフライン環境では [Vosk](https://alphacephei.com/vosk/models) から日本語モデルを取得し、
+   展開先ディレクトリを `VOSK_MODEL_PATH` 環境変数に設定してください
+3. Linux環境でローカル実行する場合は `portaudio19-dev` をインストールしてください
+4. マイクが無い環境では `PortAudioError: Error querying device` が表示されます。音声
+   入力を利用するにはマイク付きの端末で実行してください
 
 ### APIの直接利用
 

--- a/app/ui/ui.py
+++ b/app/ui/ui.py
@@ -1,6 +1,8 @@
 import os
 import queue
 import json
+import shutil
+import zipfile
 import streamlit as st
 import requests
 import sounddevice as sd
@@ -8,28 +10,69 @@ from vosk import Model, KaldiRecognizer
 
 API_URL = "http://api:8000/api/v1/user-message"
 VOSK_MODEL_PATH = os.getenv("VOSK_MODEL_PATH", "model")
+MODEL_URL = "https://alphacephei.com/vosk/models/vosk-model-small-ja-0.22.zip"
+
+
+def ensure_vosk_model() -> bool:
+    """Download the Japanese Vosk model if it's not available."""
+    if os.path.isdir(VOSK_MODEL_PATH):
+        return True
+    try:
+        st.info("Downloading Vosk Japanese model...")
+        os.makedirs(VOSK_MODEL_PATH, exist_ok=True)
+        zip_path = os.path.join(VOSK_MODEL_PATH, "model.zip")
+        with requests.get(MODEL_URL, stream=True) as r:
+            r.raise_for_status()
+            with open(zip_path, "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(VOSK_MODEL_PATH)
+        os.remove(zip_path)
+
+        # If the model is extracted into a directory, move contents up
+        for item in os.listdir(VOSK_MODEL_PATH):
+            path = os.path.join(VOSK_MODEL_PATH, item)
+            if os.path.isdir(path) and item.startswith("vosk-model"):
+                for f in os.listdir(path):
+                    shutil.move(os.path.join(path, f), VOSK_MODEL_PATH)
+                shutil.rmtree(path)
+                break
+        return True
+    except Exception as e:
+        st.error(f"Vosk model download failed: {e}")
+        return False
 
 
 def recognize_voice(duration: int = 5) -> str:
     """Record audio from microphone and transcribe it using Vosk."""
-    if not os.path.isdir(VOSK_MODEL_PATH):
-        st.error("Vosk model not found. Set VOSK_MODEL_PATH correctly.")
+    if not ensure_vosk_model():
         return ""
 
     model = Model(VOSK_MODEL_PATH)
     recognizer = KaldiRecognizer(model, 16000)
     q = queue.Queue()
 
+    try:
+        sd.query_devices(None, "input")
+    except sd.PortAudioError as e:
+        st.error(f"音声入力デバイスを取得できません: {e}")
+        return ""
+
     def callback(indata, frames, time, status):
         if status:
             st.warning(str(status))
         q.put(bytes(indata))
 
-    with sd.RawInputStream(samplerate=16000, blocksize=8000, dtype="int16",
-                           channels=1, callback=callback):
-        for _ in range(int(duration * 16000 / 8000)):
-            data = q.get()
-            recognizer.AcceptWaveform(data)
+    try:
+        with sd.RawInputStream(samplerate=16000, blocksize=8000, dtype="int16",
+                               channels=1, callback=callback):
+            for _ in range(int(duration * 16000 / 8000)):
+                data = q.get()
+                recognizer.AcceptWaveform(data)
+    except sd.PortAudioError as e:
+        st.error(f"録音に失敗しました: {e}")
+        return ""
     result = json.loads(recognizer.FinalResult())
     return result.get("text", "")
 


### PR DESCRIPTION
## Summary
- automatically download the Japanese Vosk model when missing
- clarify Japanese model instructions in README
- handle missing audio devices gracefully

## Testing
- `python -m py_compile app/ui/ui.py`


------
https://chatgpt.com/codex/tasks/task_e_684025cd456483318ef8f9a59537dad0