### PR TITLE
Add browsing analyzer for Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,24 @@ curl http://localhost:8086/api/v1/user-message \
 curl 'http://localhost:8086/api/v1/user-messages?user_id=me&limit=10'
 ```
 
+#### ブラウジング情報の送信
+
+Chrome 拡張 [curiosity-capture](https://github.com/dx-junkyard/curiosity-capture-chrome-extension) から送られるページ閲覧データを受け取るエンドポイントです。
+
+```bash
+curl http://localhost:8086/api/v1/user-actions \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com",
+    "title": "Example",
+    "text": "page text",
+    "scroll_depth": 0.5,
+    "visit_start": "2024-01-01T00:00:00Z",
+    "visit_end": "2024-01-01T00:05:00Z"
+  }'
+```
+
 ## 開発
 
 ### バックエンド（FastAPI）

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ curl 'http://localhost:8086/api/v1/user-messages?user_id=me&limit=10'
 #### ブラウジング情報の送信
 
 Chrome 拡張 [curiosity-capture](https://github.com/dx-junkyard/curiosity-capture-chrome-extension) から送られるページ閲覧データを受け取るエンドポイントです。
+初回起動時に `browsing_logs` テーブルが存在しない場合は API 側で自動的に作成されます。
 
 ```bash
 curl http://localhost:8086/api/v1/user-actions \

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ curl http://localhost:8086/api/v1/user-actions \
     "url": "https://example.com",
     "title": "Example",
     "text": "page text",
-    "scroll_depth": 0.5,
+    "scrollDepth": 0.5,
     "visit_start": "2024-01-01T00:00:00Z",
     "visit_end": "2024-01-01T00:05:00Z"
   }'

--- a/app/api/browsing_recorder.py
+++ b/app/api/browsing_recorder.py
@@ -1,0 +1,63 @@
+import mysql.connector
+from typing import Dict, Any
+from config import DB_HOST, DB_USER, DB_PASSWORD, DB_NAME, DB_PORT
+
+class BrowsingRecorder:
+    """Receive browsing data from Chrome extension and store it in MySQL."""
+
+    def __init__(self):
+        self.config = {
+            'host': DB_HOST,
+            'user': DB_USER,
+            'password': DB_PASSWORD,
+            'database': DB_NAME,
+            'port': DB_PORT,
+            'charset': 'utf8mb4'
+        }
+
+    def insert_action(self, data: Dict[str, Any]) -> None:
+        """Insert browsing action data into browsing_logs table."""
+        conn = None
+        cursor = None
+        try:
+            conn = mysql.connector.connect(**self.config)
+            cursor = conn.cursor()
+            query = """
+                INSERT INTO browsing_logs (
+                    user_id,
+                    session_id,
+                    url,
+                    title,
+                    body_text,
+                    scroll_depth,
+                    visit_start,
+                    visit_end,
+                    keywords,
+                    search_query
+                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            """
+            keywords = data.get('keywords')
+            if isinstance(keywords, list):
+                keywords = ','.join(keywords)
+            values = (
+                data.get('user_id'),
+                data.get('session_id'),
+                data.get('url'),
+                data.get('title'),
+                data.get('text'),
+                data.get('scroll_depth'),
+                data.get('visit_start'),
+                data.get('visit_end'),
+                keywords,
+                data.get('search_query')
+            )
+            cursor.execute(query, values)
+            conn.commit()
+            print("[✓] Inserted browsing log")
+        except mysql.connector.Error as err:
+            print(f"[✗] MySQL Error: {err}")
+        finally:
+            if cursor:
+                cursor.close()
+            if conn:
+                conn.close()

--- a/app/api/browsing_recorder.py
+++ b/app/api/browsing_recorder.py
@@ -14,6 +14,41 @@ class BrowsingRecorder:
             'port': DB_PORT,
             'charset': 'utf8mb4'
         }
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        """Create browsing_logs table if it doesn't exist."""
+        conn = None
+        cursor = None
+        try:
+            conn = mysql.connector.connect(**self.config)
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS browsing_logs (
+                    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                    user_id VARCHAR(255),
+                    session_id VARCHAR(255),
+                    url TEXT,
+                    title TEXT,
+                    body_text LONGTEXT,
+                    scroll_depth FLOAT,
+                    visit_start DATETIME,
+                    visit_end DATETIME,
+                    keywords TEXT,
+                    search_query TEXT,
+                    PRIMARY KEY (id)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+                """
+            )
+            conn.commit()
+        except mysql.connector.Error as err:
+            print(f"[✗] MySQL Error: {err}")
+        finally:
+            if cursor:
+                cursor.close()
+            if conn:
+                conn.close()
 
     def insert_action(self, data: Dict[str, Any]) -> None:
         """Insert browsing action data into browsing_logs table."""

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -6,6 +6,7 @@ import logging
 # config.pyからトークンやAPIエンドポイントをインポート
 from app.api.ai import AIClient
 from app.api.db import DBClient
+from app.api.browsing_recorder import BrowsingRecorder
 
 app = FastAPI()
 
@@ -29,6 +30,18 @@ async def post_usermessage(request: Request) -> str:
     repo.insert_message("me",message)
     repo.insert_message("ai",ai_response)
     return ai_response
+
+@app.post("/api/v1/user-actions")
+async def post_user_actions(request: Request) -> dict:
+    """Receive browsing data from Chrome extension."""
+    try:
+        data = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+
+    recorder = BrowsingRecorder()
+    recorder.insert_action(data)
+    return {"status": "ok"}
 
 @app.get("/api/v1/user-messages")
 async def get_user_messages(user_id: str = Query(..., description="ユーザーID"), limit: int = Query(10, ge=1, le=100, description="取得件数")) -> List[Dict]:

--- a/mysql/db/browsing_logs.sql
+++ b/mysql/db/browsing_logs.sql
@@ -1,4 +1,4 @@
-CREATE TABLE browsing_logs (
+CREATE TABLE IF NOT EXISTS browsing_logs (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     user_id VARCHAR(255),
     session_id VARCHAR(255),

--- a/mysql/db/browsing_logs.sql
+++ b/mysql/db/browsing_logs.sql
@@ -1,0 +1,14 @@
+CREATE TABLE browsing_logs (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    user_id VARCHAR(255),
+    session_id VARCHAR(255),
+    url TEXT,
+    title TEXT,
+    body_text LONGTEXT,
+    scroll_depth FLOAT,
+    visit_start DATETIME,
+    visit_end DATETIME,
+    keywords TEXT,
+    search_query TEXT,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- add BrowsingAnalyzer to accept browsing data
- create endpoint `/api/v1/user-actions`
- define `browsing_logs` table for MySQL
- document how to POST browsing data
- rename BrowsingAnalyzer to BrowsingRecorder

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6846e29ddb108331b35f4eabe7ba8d67