### PR TITLE
Store page cache and visits

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@
 │       └── audio_output.py    # 音声出力機能
 ├── voicevox/                  # VOICEVOX エンジンコンテナ
 ├── mysql/                     # MySQLデータベース関連
-│   └── db/user_messages.sql   # テーブル定義(DDL)
+│   └── db/
+│       ├── schema.sql                # テーブル定義
+│       ├── seed_root_categories.sql  # 初期データ
+│       └── user_messages.sql         # メッセージ保存テーブル
 ├── config.py                  # 設定ファイル
 ├── requirements.api.txt       # API依存関係
 ├── requirements.ui.txt        # UI依存関係
@@ -144,7 +147,7 @@ curl 'http://localhost:8086/api/v1/user-messages?user_id=me&limit=10'
 #### ブラウジング情報の送信
 
 Chrome 拡張 [curiosity-capture](https://github.com/dx-junkyard/curiosity-capture-chrome-extension) から送られるページ閲覧データを受け取るエンドポイントです。
-初回起動時に `browsing_logs` テーブルが存在しない場合は API 側で自動的に作成されます。
+利用前に `mysql/db/schema.sql` と `mysql/db/seed_root_categories.sql` を実行してテーブルと初期データを作成してください。
 
 ```bash
 curl http://localhost:8086/api/v1/user-actions \

--- a/app/api/browsing_recorder.py
+++ b/app/api/browsing_recorder.py
@@ -2,8 +2,9 @@ import json
 import logging
 import mysql.connector
 from typing import Dict, Any, Optional
+import hashlib
 from datetime import datetime
-from config import DB_HOST, DB_USER, DB_PASSWORD, DB_NAME, DB_PORT, ROOT_CATEGORIES
+from config import DB_HOST, DB_USER, DB_PASSWORD, DB_NAME, DB_PORT
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -20,80 +21,6 @@ class BrowsingRecorder:
             'port': DB_PORT,
             'charset': 'utf8mb4'
         }
-        self._ensure_table()
-
-    def _ensure_table(self) -> None:
-        """Create tables if they don't exist."""
-        conn = None
-        cursor = None
-        try:
-            conn = mysql.connector.connect(**self.config)
-            cursor = conn.cursor()
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS browsing_logs (
-                    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-                    user_id VARCHAR(255),
-                    session_id VARCHAR(255),
-                    url TEXT,
-                    title TEXT,
-                    summary TEXT,
-                    scroll_depth FLOAT,
-                    visit_start DATETIME,
-                    visit_end DATETIME,
-                    keywords TEXT,
-                    search_query TEXT,
-                    PRIMARY KEY (id)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-                """
-            )
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS root_categories (
-                    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-                    name VARCHAR(255) UNIQUE,
-                    PRIMARY KEY (id)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-                """
-            )
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS sub_categories (
-                    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-                    root_id BIGINT UNSIGNED NOT NULL,
-                    name VARCHAR(255),
-                    PRIMARY KEY (id),
-                    FOREIGN KEY (root_id) REFERENCES root_categories(id)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-                """
-            )
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS log_sub_categories (
-                    log_id BIGINT UNSIGNED NOT NULL,
-                    sub_id BIGINT UNSIGNED NOT NULL,
-                    PRIMARY KEY (log_id, sub_id),
-                    FOREIGN KEY (log_id) REFERENCES browsing_logs(id),
-                    FOREIGN KEY (sub_id) REFERENCES sub_categories(id)
-                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-                """
-            )
-            # insert root categories if table empty
-            cursor.execute("SELECT COUNT(*) FROM root_categories")
-            count = cursor.fetchone()[0]
-            if count == 0:
-                cursor.executemany(
-                    "INSERT INTO root_categories(name) VALUES (%s)",
-                    [(name,) for name in ROOT_CATEGORIES]
-                )
-            conn.commit()
-        except mysql.connector.Error as err:
-            print(f"[✗] MySQL Error: {err}")
-        finally:
-            if cursor:
-                cursor.close()
-            if conn:
-                conn.close()
 
     def _parse_datetime(self, value: Optional[str]) -> Optional[datetime]:
         """Convert ISO8601 string to naive datetime for MySQL."""
@@ -105,26 +32,13 @@ class BrowsingRecorder:
             return None
 
     def insert_action(self, data: Dict[str, Any]) -> None:
-        """Insert browsing action data into browsing_logs table."""
+        """Insert browsing action data into pages and page_visits tables."""
         conn = None
         cursor = None
         try:
             conn = mysql.connector.connect(**self.config)
             cursor = conn.cursor()
-            query = """
-                INSERT INTO browsing_logs (
-                    user_id,
-                    session_id,
-                    url,
-                    title,
-                    summary,
-                    scroll_depth,
-                    visit_start,
-                    visit_end,
-                    keywords,
-                    search_query
-                ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-            """
+
             keywords = data.get('keywords')
             if isinstance(keywords, list):
                 keywords = ','.join(keywords)
@@ -137,27 +51,33 @@ class BrowsingRecorder:
             except (ValueError, TypeError):
                 scroll_depth = None
 
-            values = (
-                data.get('user_id'),
-                data.get('session_id'),
-                data.get('url'),
-                data.get('title'),
-                data.get('summary'),
-                scroll_depth,
-                self._parse_datetime(data.get('visit_start')),
-                self._parse_datetime(data.get('visit_end')),
-                keywords,
-                data.get('search_query')
-            )
-            logger.info(
-                "Insert log url=%s title=%s summary=%s labels=%s",
-                data.get('url'),
-                data.get('title'),
-                data.get('summary'),
-                json.dumps(data.get('labels', []), ensure_ascii=False),
-            )
-            cursor.execute(query, values)
-            log_id = cursor.lastrowid
+            url = data.get('url') or ''
+            url_hash = hashlib.sha256(url.encode()).hexdigest()
+
+            # check or insert page cache
+            cursor.execute("SELECT id FROM pages WHERE url_hash=%s", (url_hash,))
+            row = cursor.fetchone()
+            if row:
+                page_id = row[0]
+            else:
+                cursor.execute(
+                    """
+                    INSERT INTO pages (url, url_hash, title, summary, labels, keywords, search_query)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s)
+                    """,
+                    (
+                        url,
+                        url_hash,
+                        data.get('title'),
+                        data.get('summary'),
+                        json.dumps(data.get('labels', []), ensure_ascii=False),
+                        keywords,
+                        data.get('search_query'),
+                    ),
+                )
+                page_id = cursor.lastrowid
+
+            # map categories to page
             labels = data.get('labels', [])
             for label in labels:
                 root_name = label.get('root')
@@ -181,9 +101,9 @@ class BrowsingRecorder:
                         "SELECT id FROM sub_categories WHERE root_id=%s AND name=%s",
                         (root_id, sub_name),
                     )
-                    row = cursor.fetchone()
-                    if row:
-                        sub_id = row[0]
+                    sub_row = cursor.fetchone()
+                    if sub_row:
+                        sub_id = sub_row[0]
                     else:
                         cursor.execute(
                             "INSERT INTO sub_categories(root_id, name) VALUES (%s,%s)",
@@ -191,11 +111,28 @@ class BrowsingRecorder:
                         )
                         sub_id = cursor.lastrowid
                     cursor.execute(
-                        "INSERT IGNORE INTO log_sub_categories(log_id, sub_id) VALUES (%s,%s)",
-                        (log_id, sub_id),
+                        "INSERT IGNORE INTO page_categories(page_id, sub_id) VALUES (%s,%s)",
+                        (page_id, sub_id),
                     )
+
+            # insert user visit record
+            cursor.execute(
+                """
+                INSERT INTO page_visits (page_id, user_id, session_id, scroll_depth, visit_start, visit_end)
+                VALUES (%s,%s,%s,%s,%s,%s)
+                """,
+                (
+                    page_id,
+                    data.get('user_id'),
+                    data.get('session_id'),
+                    scroll_depth,
+                    self._parse_datetime(data.get('visit_start')),
+                    self._parse_datetime(data.get('visit_end')),
+                ),
+            )
+
             conn.commit()
-            print("[✓] Inserted browsing log")
+            print("[✓] Inserted page visit")
         except mysql.connector.Error as err:
             print(f"[✗] MySQL Error: {err}")
         finally:

--- a/app/api/summarize_worker.py
+++ b/app/api/summarize_worker.py
@@ -3,10 +3,22 @@ import logging
 import os
 import re
 import pika
+import mysql.connector
+import hashlib
 from dotenv import load_dotenv
 from openai import OpenAI
 
-from config import MQ_HOST, MQ_RAW_QUEUE, MQ_PROCESSED_QUEUE, ROOT_CATEGORIES
+from config import (
+    MQ_HOST,
+    MQ_RAW_QUEUE,
+    MQ_PROCESSED_QUEUE,
+    ROOT_CATEGORIES,
+    DB_HOST,
+    DB_USER,
+    DB_PASSWORD,
+    DB_NAME,
+    DB_PORT,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -14,6 +26,15 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY", ""))
 ai_model = os.getenv("AI_MODEL", "gpt-4o")
+
+db_config = {
+    'host': DB_HOST,
+    'user': DB_USER,
+    'password': DB_PASSWORD,
+    'database': DB_NAME,
+    'port': DB_PORT,
+    'charset': 'utf8mb4',
+}
 
 PROMPT_TEMPLATE = """
 次のWebページ内容を日本語で要約し、root_categories から該当するものを複数選んだ上で、
@@ -35,8 +56,35 @@ root_categories = {roots}
 
 
 def analyze_action(data: dict) -> dict:
+    """Analyze page text using OpenAI API with DB caching."""
     title = data.get("title", "")
     text = data.get("text", "")[:1000]
+    url = data.get("url", "")
+    url_hash = hashlib.sha256(url.encode()).hexdigest()
+
+    # check cache
+    conn = None
+    cursor = None
+    try:
+        conn = mysql.connector.connect(**db_config)
+        cursor = conn.cursor(dictionary=True)
+        cursor.execute(
+            "SELECT summary, labels FROM pages WHERE url_hash=%s",
+            (url_hash,),
+        )
+        row = cursor.fetchone()
+        if row and row.get("summary"):
+            logger.info("Cache hit for %s", url)
+            labels = json.loads(row["labels"] or "[]")
+            return {"summary": row["summary"], "labels": labels}
+    except mysql.connector.Error as err:
+        logger.error("MySQL error: %s", err)
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
+
     prompt = PROMPT_TEMPLATE.format(title=title, text=text, roots=ROOT_CATEGORIES)
     try:
         response = client.chat.completions.create(
@@ -49,10 +97,41 @@ def analyze_action(data: dict) -> dict:
             content = re.sub(r'^```(?:json)?\s*', '', content, flags=re.IGNORECASE)
             content = re.sub(r'\s*```$', '', content)
             content = content.strip()
-        return json.loads(content)
+        result = json.loads(content)
     except Exception as exc:
         logger.error(f"OpenAI API error: {exc}")
-        return {"summary": text[:200], "labels": []}
+        result = {"summary": text[:200], "labels": []}
+
+    # store result in cache
+    conn = None
+    cursor = None
+    try:
+        conn = mysql.connector.connect(**db_config)
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO pages (url, url_hash, title, summary, labels)
+            VALUES (%s,%s,%s,%s,%s)
+            ON DUPLICATE KEY UPDATE title=VALUES(title), summary=VALUES(summary), labels=VALUES(labels)
+            """,
+            (
+                url,
+                url_hash,
+                title,
+                result.get("summary"),
+                json.dumps(result.get("labels", []), ensure_ascii=False),
+            ),
+        )
+        conn.commit()
+    except mysql.connector.Error as err:
+        logger.error("MySQL error: %s", err)
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
+
+    return result
 
 
 def main() -> None:

--- a/mysql/db/schema.sql
+++ b/mysql/db/schema.sql
@@ -1,16 +1,25 @@
-CREATE TABLE IF NOT EXISTS browsing_logs (
+CREATE TABLE IF NOT EXISTS pages (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-    user_id VARCHAR(255),
-    session_id VARCHAR(255),
     url TEXT,
+    url_hash CHAR(64) NOT NULL UNIQUE,
     title TEXT,
     summary TEXT,
-    scroll_depth FLOAT,
-    visit_start DATETIME,
-    visit_end DATETIME,
+    labels TEXT,
     keywords TEXT,
     search_query TEXT,
     PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS page_visits (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    page_id BIGINT UNSIGNED NOT NULL,
+    user_id VARCHAR(255),
+    session_id VARCHAR(255),
+    scroll_depth FLOAT,
+    visit_start DATETIME,
+    visit_end DATETIME,
+    PRIMARY KEY (id),
+    FOREIGN KEY (page_id) REFERENCES pages(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS root_categories (
@@ -27,10 +36,10 @@ CREATE TABLE IF NOT EXISTS sub_categories (
     FOREIGN KEY (root_id) REFERENCES root_categories(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE IF NOT EXISTS log_sub_categories (
-    log_id BIGINT UNSIGNED NOT NULL,
+CREATE TABLE IF NOT EXISTS page_categories (
+    page_id BIGINT UNSIGNED NOT NULL,
     sub_id BIGINT UNSIGNED NOT NULL,
-    PRIMARY KEY (log_id, sub_id),
-    FOREIGN KEY (log_id) REFERENCES browsing_logs(id),
+    PRIMARY KEY (page_id, sub_id),
+    FOREIGN KEY (page_id) REFERENCES pages(id),
     FOREIGN KEY (sub_id) REFERENCES sub_categories(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- cache browsing analysis results per page
- separate user visit records from page data
- create new DB tables to support caching
- mention manual table creation in docs
- remove table creation code from BrowsingRecorder

## Testing
- `python -m py_compile app/api/browsing_recorder.py app/api/summarize_worker.py app/api/action_worker.py app/api/main.py`


------
https://chatgpt.com/codex/tasks/task_e_684d3eb718bc8331b37b90893ec77fe2