### PR TITLE
Update uvicorn dependency

### DIFF
--- a/requirements.api.txt
+++ b/requirements.api.txt
@@ -1,5 +1,5 @@
 fastapi
-uvicorn
+uvicorn[standard]
 requests
 mysql-connector-python
 pika


### PR DESCRIPTION
## Summary
- use `uvicorn[standard]` in API dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker compose up --build -d` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685728cd2afc83319f71a2760c1988ef